### PR TITLE
Update step.sh

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -21,4 +21,4 @@ fi;
 TEMP_DIR=$(pwd)
 popd
 
-variable-injector --file ${files} $VERBOSE --ignore ${vars_to_ignore} 
+variable-injector --file ${files} $VERBOSE --ignore ${vars_to_ignore:-""}


### PR DESCRIPTION
Use default empty string in case of none of the `ignore` vars are set.

If you do not use the `ignore` option, this step will fail due to the lack of ignoring arguments.

```
👉  variable-injector --file Xuxux.swift \ --ignore ${vars_to_ignore} --verbose
Error: 2 unexpected arguments: ' --ignore', 'd'
Usage: variable-injector-tool [--verbose] [--file <file> ...] [--ignore <ignore> ...]
```

Simply add a default argument with `""` nothing inside.